### PR TITLE
Fix hook command to run recompile only if xmonad.hs exists

### DIFF
--- a/xmonad-recompile.hook
+++ b/xmonad-recompile.hook
@@ -11,4 +11,4 @@ Description = Recompile xmonad after package update
 When = PostTransaction
 Depends = coreutils
 Depends = xmonad
-Exec = /bin/sh -c 'grep "/home\|/root" /etc/passwd | cut -d ":" -f 6 | while read -r target_home_dir; do [ -w $target_home_dir -o -d $target_home_dir/.config/xmonad ] || [  -w $target_home_dir -o -d $target_home_dir/.xmonad ] && HOME=$target_home_dir && xmonad --recompile ; done'
+Exec = /bin/sh -c 'grep "/home\|/root" /etc/passwd | cut -d ":" -f 6 | while read -r target_home_dir; do [ -w $target_home_dir -a -r $target_home_dir/.config/xmonad/xmonad.hs ] || [  -w $target_home_dir -a -r $target_home_dir/.xmonad/xmonad.hs ] && HOME=$target_home_dir && xmonad --recompile ; done'


### PR DESCRIPTION
According to man page of xmonad command xmonad.hs is  expected in XMONAD_CONFIG_DIR,  ~/.xmonad or in
XDG_CONFIG_HOME.

It does not make sense to support all kind of non-standard locations. Therefore, existing implementation supports only the common locations ~/.xmonad and ~/.config/xmonad. However, it does not check if xmonad.hs file or symlink exists.

Moreover, the condition should use -a (and) not -o (or). Otherwise, recompile will happen for all home directories. All home directories that do not contain a xmonad.hs will result in an error. Each error report will be opened in a new window and pacman will be blocked until all windows have been closed.

This commit fixes this behavior for most cases. This behavior will only happen if recompile fails on an existing file. However, this can be considered as intended behavior.